### PR TITLE
Update jquery.pjax.js

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -127,7 +127,15 @@ function handleSubmit(event, container, options) {
   }
 
   if (defaults.type !== 'GET' && window.FormData !== undefined) {
+    var form_file_inputs = $(form).find(':file:not([disabled])');
+    form_file_inputs.each(function(_, input) {
+      if (input.files.length > 0) {
+        return;
+      }
+      $(input).prop('disabled', true)
+    });
     defaults.data = new FormData(form)
+    form_file_inputs.prop('disabled', false);
     defaults.processData = false
     defaults.contentType = false
   } else {


### PR DESCRIPTION
Fix bug: Safari 11.1 ajax/XHR form submission fails when input[type=file] is empty